### PR TITLE
updated groupId/artifactId for calabash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,8 +271,8 @@
                   <version>1.4</version>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>org.daisy.libs</groupId>
-                  <artifactId>com.xmlcalabash</artifactId>
+                  <groupId>com.xmlcalabash</groupId>
+                  <artifactId>xmlcalabash</artifactId>
                   <version>1.0.9</version>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
Building the assembly gave the following error:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:2.4:copy (copy-libs-bundles) on project assembly: Unable to find artifact. Failure to find org.daisy.libs:com.xmlcalabash:jar:1.0.9 in http://repo.maven.apache.org/maven2/ was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced
