### PR TITLE
Revert exec to eval to cope with unescaped env variables

### DIFF
--- a/src/main/resources/bin/pipeline2
+++ b/src/main/resources/bin/pipeline2
@@ -362,7 +362,7 @@ run() {
         JAVA_EXT_DIRS=`cygpath --path --windows "$JAVA_EXT_DIRS"`
     fi
     cd "$PIPELINE2_BASE"
-    exec "$JAVA" "$JAVA_OPTS" -Djava.endorsed.dirs="${JAVA_ENDORSED_DIRS}" -Djava.ext.dirs="${JAVA_EXT_DIRS}"  -Dorg.daisy.pipeline.home="$PIPELINE2_HOME" -Dorg.daisy.pipeline.base="$PIPELINE2_BASE" -Dorg.daisy.pipeline.data="$PIPELINE2_DATA" -Dfelix.config.properties="file:$PIPELINE2_HOME/etc/config.properties" -Dfelix.system.properties="file:$PIPELINE2_HOME/etc/system.properties" $PIPELINE2_OPTS $OPTS -classpath "$CLASSPATH" $MAIN "$@"
+    eval "$JAVA" $JAVA_OPTS -Djava.endorsed.dirs="${JAVA_ENDORSED_DIRS}" -Djava.ext.dirs="${JAVA_EXT_DIRS}"  -Dorg.daisy.pipeline.home="$PIPELINE2_HOME" -Dorg.daisy.pipeline.base="$PIPELINE2_BASE" -Dorg.daisy.pipeline.data="$PIPELINE2_DATA" -Dfelix.config.properties="file:$PIPELINE2_HOME/etc/config.properties" -Dfelix.system.properties="file:$PIPELINE2_HOME/etc/system.properties" $PIPELINE2_OPTS $OPTS -classpath "$CLASSPATH" $MAIN "$@"
 }
 
 main() {


### PR DESCRIPTION
I think this should've been merged in a former pull request
