### PR TITLE
Modules and Calabash steps needed for dtbook-to-odt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,10 @@
               <artifactItems>
                 <artifactItem>
                   <groupId>org.daisy.pipeline.modules</groupId>
+                  <artifactId>asciimath-utils</artifactId>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.daisy.pipeline.modules</groupId>
                   <artifactId>common-entities</artifactId>
                 </artifactItem>
                 <artifactItem>
@@ -544,6 +548,10 @@
                 <artifactItem>
                   <groupId>org.daisy.pipeline.modules</groupId>
                   <artifactId>html-utils</artifactId>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.daisy.pipeline.modules</groupId>
+                  <artifactId>image-utils</artifactId>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.daisy.pipeline.modules</groupId>

--- a/src/main/resources/etc/config-calabash.xml
+++ b/src/main/resources/etc/config-calabash.xml
@@ -9,5 +9,6 @@
 <implementation type="px:mkdir" class-name="com.xmlcalabash.extensions.fileutils.Mkdir"/>
 <implementation type="px:tempfile" class-name="com.xmlcalabash.extensions.fileutils.Tempfile"/>
 <implementation type="px:zip" class-name="com.xmlcalabash.extensions.Zip"/>
+<implementation type="px:unzip" class-name="com.xmlcalabash.extensions.Unzip"/>
 
 </xproc-config>


### PR DESCRIPTION
The modules asciimath-utils and image-utils are needed by sbs:dtbook-to-odt. They are currently not used anywhere else, so if you don't want to put them in the assembly yet, that's okay, we can install them ourselfs. But the px:unzip step would be great so that we don't have to fork the assembly in order to create our own Debian package.

(Another solution would be to make config-calabash.xml a "real" Debian config file, which means Debian will do the right thing when updating. But I think it's more like a system file that should not be changed. Why do we need this file by the way, is it because we use the px: prefix instead of cx:?)
