### PR TITLE
EPUB 3 Validator script using EpubCheck v4.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>scripts-aggregator</artifactId>
-        <version>1.9</version>
+        <version>1.9.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -58,7 +58,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>script-utils-aggregator</artifactId>
-        <version>1.9</version>
+        <version>1.9.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -684,6 +684,42 @@
                   <groupId>org.daisy.pipeline.modules</groupId>
                   <artifactId>epub3-to-ssml</artifactId>
                 </artifactItem>
+                
+                <!-- epub3-validator + dependencies -->
+                <artifactItem>
+                  <groupId>org.daisy.pipeline.modules</groupId>
+                  <artifactId>epub3-validator</artifactId>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.daisy.pipeline.modules</groupId>
+                  <artifactId>epubcheck-adapter</artifactId>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.idpf</groupId>
+                  <artifactId>epubcheck</artifactId>
+                  <version>4.0.1</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.google.guava</groupId>
+                  <artifactId>guava</artifactId>
+                  <version>14.0.1</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.commons</groupId>
+                  <artifactId>commons-compress</artifactId>
+                  <version>1.5</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.codehaus.jackson</groupId>
+                  <artifactId>jackson-core-asl</artifactId>
+                  <version>1.9.12</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.codehaus.jackson</groupId>
+                  <artifactId>jackson-mapper-asl</artifactId>
+                  <version>1.9.12</version>
+                </artifactItem>
+                
                 <artifactItem>
                   <groupId>org.daisy.pipeline.modules</groupId>
                   <artifactId>epub3-to-daisy202</artifactId>


### PR DESCRIPTION
~~References epubcheck:4.0.0-alpha12 (see IDPF/epubcheck#471) and its dependencies.~~ Also enables the EPUB3 Validator script, which should work after this is merged.

~~Depends on pull requests:
daisy/pipeline-scripts-utils#59
daisy/pipeline-scripts#54~~

I wasn't quite sure where to list these dependencies. The build doesn't seem to pull in transitive dependencies so I specified them here so that they are included in the resulting build.
