### PR TITLE
Depend on java7-runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -953,6 +953,7 @@
     <profile>
       <id>deb</id>
       <properties>
+        <pipeline.user>pipeline2</pipeline.user>
         <pipeline.home>/opt/daisy-pipeline2</pipeline.home>
         <pipeline.data>/var/opt/daisy-pipeline2</pipeline.data>
         <pipeline.log>/var/log/daisy-pipeline2</pipeline.log>

--- a/src/main/deb/DEBIAN/control
+++ b/src/main/deb/DEBIAN/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: text
 Priority: optional
 Architecture: all
-Depends: debconf, lsb-base (>= 3.0-6), java-runtime, ruby-interpreter
+Depends: debconf, lsb-base (>= 3.0-6), java7-runtime, ruby-interpreter
 Maintainer: Romain Deltour <romain.deltour@gmail.com>
 Description: DAISY Pipeline 2
  .

--- a/src/main/deb/DEBIAN/control
+++ b/src/main/deb/DEBIAN/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: text
 Priority: optional
 Architecture: all
-Depends: debconf, lsb-base (>= 3.0-6), java7-runtime, ruby-interpreter
+Depends: debconf, lsb-base (>= 3.0-6), adduser (>= 3.9), java7-runtime, ruby-interpreter
 Maintainer: Romain Deltour <romain.deltour@gmail.com>
 Description: DAISY Pipeline 2
  .

--- a/src/main/deb/DEBIAN/postinst
+++ b/src/main/deb/DEBIAN/postinst
@@ -37,6 +37,21 @@ case "$1" in
     
     configure)
         
+        # create ${pipeline.user} group
+        if ! getent group ${pipeline.user} >/dev/null; then
+            addgroup --system ${pipeline.user}
+        fi
+        
+        # create ${pipeline.user} user
+        if ! getent passwd ${pipeline.user} >/dev/null; then
+            adduser --system --group --home ${pipeline.data} --no-create-home --disabled-login \
+                --gecos "DAISY Pipeline 2 server" ${pipeline.user}
+        fi
+        
+        mkdir -p ${pipeline.data}
+        chown -R ${pipeline.user}:${pipeline.user} ${pipeline.data}
+        chown -R ${pipeline.user}:${pipeline.user} ${pipeline.log}
+        
         if [ ! -e $SYSTEM_PROPERTIES ]; then
             echo "$SYSTEM_PROPERTIES: no such file" >&2 && exit 1
         fi

--- a/src/main/deb/etc/init.d/pipeline2d
+++ b/src/main/deb/etc/init.d/pipeline2d
@@ -38,33 +38,6 @@ fi
 # Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
 . /lib/lsb/init-functions
 
-check_java_version() {
-  local JAVA VERSION
-  if [ "x$JAVA" = "x" ]; then
-	if [ "x$JAVA_HOME" != "x" ]; then
-	  if [ -x "$JAVA_HOME/bin/java" ]; then
-		JAVA="$JAVA_HOME/bin/java"
-	  else
-		echo "no java executable in JAVA_HOME: $JAVA_HOME"
-		return 1
-	  fi
-	else
-	  JAVA=`type java`
-	  JAVA=`expr "$JAVA" : '.*is \(.*\)$'`
-	  if [ "x$JAVA" = "x" ]; then
-		echo "java command not found"
-		return 1
-	  fi
-	fi
-  fi
-  VERSION=$("$JAVA" -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
-  if [ "$VERSION" -lt "17" ]; then
-	echo "java version must be at least 1.7"
-	return 1
-  fi
-  return 0
-}
-
 #
 # Function that starts the daemon/service
 #
@@ -77,7 +50,6 @@ do_start()
 	start-stop-daemon --start --quiet --make-pidfile --pidfile $PIDFILE --startas $DAEMON \
 		--background --test > /dev/null \
 		|| return 1
-    check_java_version || return 2
 	start-stop-daemon --start --quiet --make-pidfile --pidfile $PIDFILE --startas $DAEMON \
 		--background -- $DAEMON_ARGS \
 		|| return 2

--- a/src/main/deb/etc/init.d/pipeline2d
+++ b/src/main/deb/etc/init.d/pipeline2d
@@ -50,14 +50,26 @@ do_start()
 	start-stop-daemon --start --quiet --make-pidfile --pidfile $PIDFILE --startas $DAEMON \
 		--background --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --quiet --make-pidfile --pidfile $PIDFILE --startas $DAEMON \
-		--background -- $DAEMON_ARGS \
-		|| return 2
-
-	# Add code here, if necessary, that waits for the process to be ready
-	# to handle requests from services started subsequently which depend
-	# on this one.  As a last resort, sleep for some time.
-	sleep 5
+	LOG=$(mktemp /tmp/pipeline2.log.XXXXXXXX)
+	start-stop-daemon --start --quiet --make-pidfile --pidfile $PIDFILE --background \
+		--startas /bin/bash -- -c "exec $DAEMON $DAEMON_ARGS > $LOG 2>&1"
+	if [ "$?" -ne 0 ]; then
+		rv=2
+	else
+		sleep 1
+		if ! ps -p $(cat "$PIDFILE") >/dev/null; then
+			rv=2
+			cat $LOG 1>&2
+		else
+			rv=0
+			# Add code here, if necessary, that waits for the process to be ready
+			# to handle requests from services started subsequently which depend
+			# on this one.	As a last resort, sleep for some time.
+			sleep 4
+		fi
+	fi
+	rm $LOG
+	return $rv
 }
 
 #

--- a/src/main/deb/etc/init.d/pipeline2d
+++ b/src/main/deb/etc/init.d/pipeline2d
@@ -17,6 +17,7 @@ DESC="DAISY Pipeline 2 server"         # Introduce a short description here
 NAME=pipeline2d                        # Introduce the short server's name here
 DAEMON=${pipeline.home}/bin/pipeline2  # Introduce the server's location here
 DAEMON_ARGS=""                         # Arguments to run the daemon with
+DAEMON_USER=${pipeline.user}
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
@@ -48,10 +49,11 @@ do_start()
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
 	start-stop-daemon --start --quiet --make-pidfile --pidfile $PIDFILE --startas $DAEMON \
-		--background --test > /dev/null \
+		--chuid $DAEMON_USER --background --test > /dev/null \
 		|| return 1
 	LOG=$(mktemp /tmp/pipeline2.log.XXXXXXXX)
-	start-stop-daemon --start --quiet --make-pidfile --pidfile $PIDFILE --background \
+	chown $DAEMON_USER $LOG
+	start-stop-daemon --start --quiet --make-pidfile --pidfile $PIDFILE --chuid $DAEMON_USER --background \
 		--startas /bin/bash -- -c "exec $DAEMON $DAEMON_ARGS > $LOG 2>&1"
 	if [ "$?" -ne 0 ]; then
 		rv=2

--- a/src/main/deb/opt/daisy-pipeline2/bin/debian.cfg
+++ b/src/main/deb/opt/daisy-pipeline2/bin/debian.cfg
@@ -1,3 +1,6 @@
+if [ "$(id --name --user)" != ${pipeline.user} ]; then
+   die "Program must be run as user \`${pipeline.user}'. Try: \"sudo -u ${pipeline.user} $0\""
+fi
 PIPELINE2_HOME="${pipeline.home}"
 PIPELINE2_BASE=$PIPELINE2_HOME
 PIPELINE2_DATA="${pipeline.data}"

--- a/src/main/resources/bin/pipeline2
+++ b/src/main/resources/bin/pipeline2
@@ -225,6 +225,15 @@ locateJava() {
     fi
 }
 
+checkJavaVersion() {
+    local VERSION
+    VERSION=$( "$JAVA" -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q' )
+    if [ "$VERSION" -lt "17" ]; then
+        die "Java version must be at least 1.7"
+    fi
+    return 0
+}
+
 detectJVM() {
    #echo "`$JAVA -version`"
    # This service should call `java -version`,
@@ -321,6 +330,9 @@ init() {
 
     # Locate the Java VM to execute
     locateJava
+    
+    # Check Java version
+    checkJavaVersion
 
     # Determine the JVM vendor
     detectJVM

--- a/src/main/resources/bin/pipeline2
+++ b/src/main/resources/bin/pipeline2
@@ -396,7 +396,7 @@ run() {
     fi
     cd "$PIPELINE2_BASE"
 
-    eval "\"$JAVA"\" $JAVA_OPTS -Djava.endorsed.dirs="\"${JAVA_ENDORSED_DIRS}"\" -Djava.ext.dirs="\"${JAVA_EXT_DIRS}"\"  -Dorg.daisy.pipeline.home="\"$PIPELINE2_HOME"\" -Dorg.daisy.pipeline.base="\"$PIPELINE2_BASE"\" -Dorg.daisy.pipeline.data="\"$PIPELINE2_DATA"\" -Dfelix.config.properties="\"file:$PIPELINE2_HOME/etc/config.properties"\" -Dfelix.system.properties="\"file:$PIPELINE2_CONFIG/system.properties"\" $PIPELINE2_OPTS $OPTS -classpath "\"$CLASSPATH"\" $MAIN "\"$@"\"
+    eval exec "\"$JAVA"\" "$JAVA_OPTS" -Djava.endorsed.dirs="\"${JAVA_ENDORSED_DIRS}"\" -Djava.ext.dirs="\"${JAVA_EXT_DIRS}"\"  -Dorg.daisy.pipeline.home="\"$PIPELINE2_HOME"\" -Dorg.daisy.pipeline.base="\"$PIPELINE2_BASE"\" -Dorg.daisy.pipeline.data="\"$PIPELINE2_DATA"\" -Dfelix.config.properties="\"file:$PIPELINE2_HOME/etc/config.properties"\" -Dfelix.system.properties="\"file:$PIPELINE2_CONFIG/system.properties"\" $PIPELINE2_OPTS $OPTS -classpath "\"$CLASSPATH"\" $MAIN "\"$@"\"
 }
 
 main() {


### PR DESCRIPTION
then we don't need to check for a specific Java version in the start script.

Since we can check for Java 7 runtime using the depends field in the control file we no longer need to check for Java 7 in the startup script.
