### PR TITLE
match openjdk version "1.8.0_45-internal"

### DIFF
--- a/src/main/resources/bin/pipeline2
+++ b/src/main/resources/bin/pipeline2
@@ -234,7 +234,7 @@ locateJava() {
 
 checkJavaVersion() {
     local VERSION
-    VERSION=$( "$JAVA" -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q' )
+    VERSION=$( "$JAVA" -version 2>&1 | sed 's/[^ ]* version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q' )
     if [ "$VERSION" -lt "17" ]; then
         die "Java version must be at least 1.7"
     fi


### PR DESCRIPTION
My java version on Ubuntu 15.04:

```sh
➜  ~  java -version
openjdk version "1.8.0_45-internal"
OpenJDK Runtime Environment (build 1.8.0_45-internal-b14)
OpenJDK 64-Bit Server VM (build 25.45-b02, mixed mode)
```

This PR changes the regex to match "openjdk" as well as "java".