### PR TITLE
Fix problem with variable ${pipeline.log.jobappender} for RPM package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1109,6 +1109,7 @@
         <bundles.auto.deploy>system/felix</bundles.auto.deploy> <!-- don't change! must be the same as in dist.properties -->
         <bundles.bootstrap>system/bootstrap</bundles.bootstrap> <!-- don't change! must be the same as in dist.properties -->
         <bundles.modules>modules</bundles.modules> <!-- don't change! must be the same as in dist.properties -->
+        <pipeline.log.jobappender>org.daisy.pipeline.logging.IgnoreSiftAppender</pipeline.log.jobappender>
       </properties>
       <build>
         <plugins>
@@ -1199,6 +1200,7 @@
                         <include>etc/system.properties</include>
                         <include>etc/config.properties</include>
                         <include>etc/org.apache.felix.fileinstall-modules.cfg</include>
+                        <include>etc/config-logback.xml</include>
                       </includes>
                       <filter>true</filter>
                     </source>


### PR DESCRIPTION
I have done the change that Bert requested for the variable ${pipeline.log.jobappender} and I hope that you guys can merge it to your daisy-master branch
