### PR TITLE
Fix issue of having to include multiple versions of Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -812,13 +812,8 @@
                   <artifactId>epubcheck-adapter</artifactId>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>org.idpf</groupId>
+                  <groupId>org.daisy</groupId>
                   <artifactId>epubcheck</artifactId>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.guava</groupId>
-                  <artifactId>guava</artifactId>
-                  <version>14.0.1</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Depends on:
- [x] ~~https://github.com/daisy/epubcheck/compare/master...daisy:update-guava~~ (**EDIT**: we'll use the latest (IDPF) version of epubcheck instead, which is using guava 24.0 (see https://github.com/IDPF/epubcheck/issues/832))
- [ ] https://github.com/daisy/pipeline-scripts-utils/commit/0fd479153e80e4e9218e8b5ca4a4c0c36d377fa3