### PR TITLE
Release 1.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1647,6 +1647,47 @@
                   <finalName>pipeline2-${project.version}_linux</finalName>
                 </configuration>
               </execution>
+              <execution>
+                <id>dist-mac</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>dist-win</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-app-package</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install-node</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>install-appdmg</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>exec-appdmg</id>
+                <phase>none</phase>
+              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>org.apache.felix</groupId>
         <artifactId>org.apache.felix.main</artifactId>
-        <version>4.4.1</version>
+        <version>5.6.2</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
@@ -222,7 +222,7 @@
                 <artifactItem>
                   <groupId>org.apache.felix</groupId>
                   <artifactId>org.apache.felix.scr</artifactId>
-                  <version>1.6.2</version>
+                  <version>2.0.8</version>
                 </artifactItem>
                 <!-- From managed dependencies -->
                 <artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>tts-modules-bom</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2456,6 +2456,7 @@
         <bundles.auto.deploy>system/felix</bundles.auto.deploy> <!-- don't change! must be the same as in dist.properties -->
         <bundles.bootstrap>system/bootstrap</bundles.bootstrap> <!-- don't change! must be the same as in dist.properties -->
         <bundles.modules>modules</bundles.modules> <!-- don't change! must be the same as in dist.properties -->
+        <pipeline.log.jobappender>org.daisy.pipeline.logging.IgnoreSiftAppender</pipeline.log.jobappender>
       </properties>
       <build>
         <plugins>
@@ -2546,6 +2547,7 @@
                         <include>etc/system.properties</include>
                         <include>etc/config.properties</include>
                         <include>etc/org.apache.felix.fileinstall-modules.cfg</include>
+                        <include>etc/config-logback.xml</include>
                       </includes>
                       <filter>true</filter>
                     </source>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>updater-gui</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.felix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -598,10 +598,6 @@
                   <groupId>org.daisy.pipeline</groupId>
                   <artifactId>calabash-adapter</artifactId>
                 </artifactItem>
-                <!--<artifactItem>
-                  <groupId>org.daisy.pipeline</groupId>
-                  <artifactId>calabash-custom-steps</artifactId>
-                </artifactItem>-->
                 <artifactItem>
                   <groupId>org.daisy.pipeline</groupId>
                   <artifactId>common-utils</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1018,10 +1018,6 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.daisy.pipeline.modules.braille</groupId>
-                  <artifactId>css-calabash</artifactId>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.daisy.pipeline.modules.braille</groupId>
                   <artifactId>css-core</artifactId>
                 </artifactItem>
                 <artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>framework-bom</artifactId>
-        <version>1.10.3-SNAPSHOT</version>
+        <version>1.10.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -66,21 +66,21 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>common-utils-bom</artifactId>
-        <version>1.10.3-SNAPSHOT</version>
+        <version>1.10.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>scripts-utils-bom</artifactId>
-        <version>1.10.2-SNAPSHOT</version>
+        <version>1.10.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>braille-modules-bom</artifactId>
-        <version>1.10.1-SNAPSHOT</version>
+        <version>1.10.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -94,7 +94,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>tts-modules-bom</artifactId>
-        <version>1.10.2-SNAPSHOT</version>
+        <version>1.10.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2006,6 +2006,39 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-app-package</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install-node</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>install-appdmg</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>exec-appdmg</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,6 @@
   <properties>
     <cli.version>2.1.0</cli.version>
   </properties>
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.felix</groupId>
-      <artifactId>org.apache.felix.main</artifactId>
-      <version>4.4.1</version>
-    </dependency>
-  </dependencies>
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -52,37 +45,42 @@
         <version>1.0.0</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>org.apache.felix.main</artifactId>
+        <version>4.4.1</version>
+      </dependency>
+      <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>framework-bom</artifactId>
-        <version>1.10.2</version>
+        <version>1.10.3-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>scripts-bom</artifactId>
-        <version>1.10.1</version>
+        <version>1.10.2-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>common-utils-bom</artifactId>
-        <version>1.10.2</version>
+        <version>1.10.3-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>scripts-utils-bom</artifactId>
-        <version>1.10.1</version>
+        <version>1.10.2-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules.braille</groupId>
         <artifactId>braille-modules-bom</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -230,8 +228,6 @@
                 <artifactItem>
                   <groupId>org.osgi</groupId>
                   <artifactId>org.osgi.enterprise</artifactId>
-                  <!-- FIXME fix that version in the fwk BoM -->
-                  <version>4.2.0</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.slf4j</groupId>
@@ -256,54 +252,41 @@
             <configuration>
               <outputDirectory>${project.build.directory}/bundles/libs/persistence</outputDirectory>
               <artifactItems>
-                <!-- Note: 1.1.0 requires EclipseLink org.eclipse.persistence.asm:3.3.1.v201206041142
-                                    which doesn't seem to be accepted by Felix (JarInputStream) -->
                 <artifactItem>
                   <groupId>org.eclipse</groupId>
                   <artifactId>org.eclipse.gemini.jpa</artifactId>
-                  <version>1.0.0.RELEASE</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.eclipse.gemini</groupId>
                   <artifactId>org.eclipse.gemini.dbaccess.derby</artifactId>
-                  <version>1.1.0.RELEASE</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.eclipse.gemini</groupId>
                   <artifactId>org.eclipse.gemini.dbaccess.util</artifactId>
-                  <version>1.1.0.RELEASE</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.eclipse.persistence</groupId>
                   <artifactId>org.eclipse.persistence.asm</artifactId>
-                  <version>2.3.2</version>
-                  <!-- <version>3.3.1.v201206041142</version> -->
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.eclipse.persistence</groupId>
                   <artifactId>org.eclipse.persistence.antlr</artifactId>
-                  <version>2.3.2</version>
-                  <!-- <version>3.2.0.v201206041011</version> -->
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.eclipse.persistence</groupId>
                   <artifactId>org.eclipse.persistence.core</artifactId>
-                  <version>2.3.2</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.eclipse.persistence</groupId>
                   <artifactId>org.eclipse.persistence.jpa</artifactId>
-                  <version>2.3.2</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.eclipse.persistence</groupId>
                   <artifactId>javax.persistence</artifactId>
-                  <version>2.0.3</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.eclipse.gemini</groupId>
                   <artifactId>org.apache.derby</artifactId>
-                  <version>10.8.2.2</version>
                 </artifactItem>
                 <!--<artifactItem>-->
                 <!--<groupId>org.daisy.pipeline</groupId>-->
@@ -323,53 +306,43 @@
                 <artifactItem>
                   <groupId>javax.xml.crypto</groupId>
                   <artifactId>jsr105-api</artifactId>
-                  <version>1.0.1</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>javax.xml.parsers</groupId>
                   <artifactId>jaxp-api</artifactId>
-                  <version>1.4.5</version>
                 </artifactItem>
                 <!-- Runtime dependencies -->
                 <artifactItem>
                   <groupId>org.apache.httpcomponents</groupId>
                   <artifactId>httpclient-osgi</artifactId>
-                  <version>4.2.5</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.apache.httpcomponents</groupId>
                   <artifactId>httpcore-osgi</artifactId>
-                  <version>4.2.4</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.daisy.libs</groupId>
                   <artifactId>jing</artifactId>
-                  <version>20120724.0.0</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>nu.validator.htmlparser</groupId>
                   <artifactId>htmlparser</artifactId>
-                  <version>1.4</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.daisy.libs</groupId>
                   <artifactId>com.xmlcalabash</artifactId>
-                  <version>1.0.23</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.daisy.libs</groupId>
                   <artifactId>logback-osgi-adapter</artifactId>
-                  <version>1.0.0</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.daisy.libs</groupId>
                   <artifactId>saxon-he</artifactId>
-                  <version>9.5.1.5</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.daisy.libs</groupId>
                   <artifactId>servlet-api</artifactId>
-                  <version>2.5.0</version>
                 </artifactItem>
                 <!-- From dependencies used at compile time in the Framework parent POM -->
                 <artifactItem>
@@ -447,17 +420,14 @@
                 <artifactItem>
                   <groupId>com.mysql.jdbc</groupId>
                   <artifactId>com.springsource.com.mysql.jdbc</artifactId>
-                  <version>5.1.6</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>net.java.dev.jna</groupId>
                   <artifactId>jna</artifactId>
-                  <version>4.0.0</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.daisy.libs</groupId>
                   <artifactId>jnaerator</artifactId>
-                  <version>0.11</version>
                 </artifactItem>
                 <artifactItem>
                   <!-- required by jstyleparser -->
@@ -475,7 +445,6 @@
                 <artifactItem>
                   <groupId>org.apache.commons</groupId>
                   <artifactId>commons-lang3</artifactId>
-                  <version>3.4</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>com.googlecode.texhyphj</groupId>
@@ -675,7 +644,6 @@
                 <artifactItem>
                   <groupId>de.codecentric.centerdevice</groupId>
                   <artifactId>centerdevice-nsmenufx</artifactId>
-                  <version>2.1.0</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.daisy.pipeline</groupId>
@@ -684,12 +652,10 @@
                 <artifactItem>
                   <groupId>org.daisy.libs</groupId>
                   <artifactId>pegdown</artifactId>
-                  <version>1.0.0</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.daisy.libs</groupId>
                   <artifactId>parboiled</artifactId>
-                  <version>1.0.0</version>
                 </artifactItem>
                 <!--<artifactItem>-->
                 <!--<groupId>org.daisy.libs</groupId>-->
@@ -699,27 +665,22 @@
                 <artifactItem>
                   <groupId>org.ow2.asm</groupId>
                   <artifactId>asm</artifactId>
-                  <version>5.0.3</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.ow2.asm</groupId>
                   <artifactId>asm-analysis</artifactId>
-                  <version>5.0.3</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.ow2.asm</groupId>
                   <artifactId>asm-tree</artifactId>
-                  <version>5.0.3</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.ow2.asm</groupId>
                   <artifactId>asm-util</artifactId>
-                  <version>5.0.3</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.parboiled</groupId>
                   <artifactId>parboiled-core</artifactId>
-                  <version>1.1.7</version>
                 </artifactItem>
               </artifactItems>
             </configuration>
@@ -853,7 +814,6 @@
                 <artifactItem>
                   <groupId>org.idpf</groupId>
                   <artifactId>epubcheck</artifactId>
-                  <version>4.0.1</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>com.google.guava</groupId>
@@ -863,17 +823,14 @@
                 <artifactItem>
                   <groupId>org.apache.commons</groupId>
                   <artifactId>commons-compress</artifactId>
-                  <version>1.5</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.codehaus.jackson</groupId>
                   <artifactId>jackson-core-asl</artifactId>
-                  <version>1.9.12</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.codehaus.jackson</groupId>
                   <artifactId>jackson-mapper-asl</artifactId>
-                  <version>1.9.12</version>
                 </artifactItem>
                 
                 <artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>updater-gui</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.felix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.daisy.pipeline</groupId>
   <artifactId>assembly</artifactId>
-  <version>1.10.2</version>
+  <version>1.10.3-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>DAISY Pipeline 2 :: Assembly</name>
   <description>Builds the main distribution of the DAISY Pipeline 2.</description>
@@ -17,7 +17,7 @@
     <connection>scm:git:git@github.com:daisy-consortium/pipeline-assembly.git</connection>
     <url>scm:git:git@github.com:daisy-consortium/pipeline-assembly.git</url>
     <developerConnection>scm:git:git@github.com:daisy-consortium/pipeline-assembly.git</developerConnection>
-    <tag>v1.10.2</tag>
+    <tag>HEAD</tag>
   </scm>
   <properties>
     <cli.version>2.1.0</cli.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.daisy.pipeline</groupId>
   <artifactId>assembly</artifactId>
-  <version>1.10.2-SNAPSHOT</version>
+  <version>1.10.2</version>
   <packaging>pom</packaging>
   <name>DAISY Pipeline 2 :: Assembly</name>
   <description>Builds the main distribution of the DAISY Pipeline 2.</description>
@@ -17,7 +17,7 @@
     <connection>scm:git:git@github.com:daisy-consortium/pipeline-assembly.git</connection>
     <url>scm:git:git@github.com:daisy-consortium/pipeline-assembly.git</url>
     <developerConnection>scm:git:git@github.com:daisy-consortium/pipeline-assembly.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v1.10.2</tag>
   </scm>
   <properties>
     <cli.version>2.1.0</cli.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1818,6 +1818,39 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-app-package</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install-node</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>install-appdmg</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>exec-appdmg</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>scripts-bom</artifactId>
-        <version>1.10.2-SNAPSHOT</version>
+        <version>1.10.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -94,7 +94,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>tts-modules-bom</artifactId>
-        <version>1.10.1</version>
+        <version>1.10.2-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/resources/README.txt
+++ b/src/main/resources/README.txt
@@ -1,4 +1,4 @@
-              DAISY Pipeline 2 - 1.10.2 - August 17, 2017
+              DAISY Pipeline 2 - 1.10.2 - August 21, 2017
 ==============================================================================
 
 
@@ -100,8 +100,8 @@ This is a release candidate.
 - daisy202-validator
   - [FIX] Attribute "shape" not allowed here
 - Braille modules
-  - Update to latest Dotify releases
-  - Add validation-status to `pef-validate`
+  - See details at:
+    https://github.com/daisy/pipeline-mod-braille/blob/master/NEWS.md#v1101
 - TTS modules
   - [FIX] problem finding lame
 - Utility modules

--- a/src/main/resources/README.txt
+++ b/src/main/resources/README.txt
@@ -79,6 +79,7 @@ This is a release candidate.
 
 ### Framework and API
 
+- Improve launch-time stability
 - Support file names with spaces inside zipped job context
 - Improve search algorithm for binaries
 - [FIX] Spaces in paths of book files cause job failure
@@ -86,7 +87,6 @@ This is a release candidate.
 ### Modules
 
 - Add basic tests for all scripts
-- Re-enable all XSpec and and XProcSpec tests
 - daisy202-to-epub3
   - [FIX] smil references inside links should also be removed
   - [FIX] Whenever a `epub:textref` attribute is added to a SMIL, an
@@ -100,14 +100,12 @@ This is a release candidate.
 - daisy202-validator
   - [FIX] Attribute "shape" not allowed here
 - Braille modules
-  - Improve launch-time stability
   - Update to latest Dotify releases
   - Add validation-status to `pef-validate`
 - TTS modules
   - [FIX] problem finding lame
 - Utility modules
   - [fileset-utils] change the actual base URI of documents in `px:fileset-load`
-  - [FIX] Circular dependency between `fileset-utils` and `mediatype-utils`
 
 ### Build maintenance
 
@@ -119,6 +117,8 @@ This is a release candidate.
   modules tests
 - Various enhancements to the `pax-exam-helper` test helper
 - Various improvements to the `xproc-maven-plugin`
+- Re-enable all XSpec and and XProcSpec tests in the modules
+
 
 
 See also the full release notes on the release page:

--- a/src/main/resources/README.txt
+++ b/src/main/resources/README.txt
@@ -1,4 +1,4 @@
-              DAISY Pipeline 2 - 1.10.0-rc1 - November 21, 2016
+              DAISY Pipeline 2 - 1.10.2 - August 17, 2017
 ==============================================================================
 
 
@@ -68,53 +68,63 @@ The package includes:
 3. Release Notes
 ------------------------------------------------------------------------------
 
-The package includes the 1.10.0-rc1 version of the project.
+The package includes the 1.10.2 version of the project.
 This is a release candidate.
 
-### Changes in v1.10.0-rc1
+### Installer/Updater
 
-* Distribution
-  * [NEW] new graphical user interface (GUI)
-  * [NEW] installers for the GUI on Windows
-  * [NEW] packaged application on Mac OS X
-  * online Java installer bundled in the Windows installer
-  * Java Runtime Environment bundled in the Mac OS X app
+- [FIX] Updater couldn't find the Pipeline installation from the registry on
+  64bit Windows
+- [FIX] Updater couldn't find releases info ("404 not found")
 
-* Command Line Interface
-  * [NEW] `clean` command to remove jobs with an `ERROR` status
-  * inputs and options arguments are no longer prefixed with `--i` and `--x`
-  * the `version` command now works as expected
-  * Properly detect Java under OpenJDK and Ubuntu 15.04
+### Framework and API
 
-* Framework and API
-  * [NEW] Add datatypes to options and list them through the api
-  * [NEW] Expose the default value for options
-  * [NEW] Add support for job batches
-  * Get rid of the folder in zipped ports and options
-  * Catch out of memory errors
-  * Return a more meaningful error when inputs are not corect
-  * Improved control of script removal
-  * Improved logging filters
-  * Normalize whitespace in script documentation parsing
-  * Do not strip out spaces if xml:space="preserve"
-  * Allow posting job requests using a namespace prefix   
+- Support file names with spaces inside zipped job context
+- Improve search algorithm for binaries
+- [FIX] Spaces in paths of book files cause job failure
 
-* Modules
-  * [NEW] DAISY 2.02 validator
-  * [NEW] DAISY 3 (audio-only) to DAISY 2.02
-  * [NEW] EPUB 3 validator (EpubCheck)
-  * [NEW] EPUB 3 to PEF script
-  * [NEW] HTML to PEF script
-  * Experimental audio-only DAISY 3 production
-  * Improved MathML production in DAISY 3
-  * Improved NIMAS validation
-  * Optimized fileset lading
-  * ... and various other bug fixes
+### Modules
+
+- Add basic tests for all scripts
+- Re-enable all XSpec and and XProcSpec tests
+- daisy202-to-epub3
+  - [FIX] smil references inside links should also be removed
+  - [FIX] Whenever a `epub:textref` attribute is added to a SMIL, an
+    `attribute-value` attribute with the same value is added
+  - [FIX] `epub:textref` in SMIL refers to `.html` files instead of `.xhtml`
+    files
+  - [FIX] Remove superfluous xmlns:d from package document metadata
+- dtbook-to-epub3
+  - [FIX] Issue with whitespace being removed
+  - [FIX] The "assert validity" option on dtbook-to-epub3 does not seem to work
+- daisy202-validator
+  - [FIX] Attribute "shape" not allowed here
+- Braille modules
+  - Improve launch-time stability
+  - Update to latest Dotify releases
+  - Add validation-status to `pef-validate`
+- TTS modules
+  - [FIX] problem finding lame
+- Utility modules
+  - [fileset-utils] change the actual base URI of documents in `px:fileset-load`
+  - [FIX] Circular dependency between `fileset-utils` and `mediatype-utils`
+
+### Build maintenance
+
+- Cleanup dependencies in Maven POMs
+- Update Calabash to v1.1.9
+- Reorganize the build of some modified/OSGified 3rd party libraries
+- Move web API tests to the `pipeline-framework` project
+- Add a `modules-test-helper` project for reducing boiloplate in Pipeline
+  modules tests
+- Various enhancements to the `pax-exam-helper` test helper
+- Various improvements to the `xproc-maven-plugin`
+
 
 See also the full release notes on the release page:
-  https://github.com/daisy/pipeline-assembly/releases/tag/v1.10.0-beta1
+  https://github.com/daisy/pipeline-assembly/releases/tag/v1.10.2
 
-4. Prerequisites                   
+4. Prerequisites
 ------------------------------------------------------------------------------
 
 Modules already include their dependent libraries and only require a recent
@@ -139,7 +149,7 @@ For instance:
 	--output "C:\Users\John Doe\Desktop\out"
 
 
-will run the DTBook to ZedAI converter on Windows and will output the result 
+will run the DTBook to ZedAI converter on Windows and will output the result
 in the "out" directory on the desktop of the user named "John Doe".
 
 
@@ -156,12 +166,12 @@ in the "out" directory on the desktop of the user named "John Doe".
 
 6. Documentation
 ------------------------------------------------------------------------------
-  
+
   Usage dp2 [GLOBAL_OPTIONS] command [COMMAND_OPTIONS] [PARAMS]
-  
-  
+
+
   Script commands:
-  
+
      daisy202-to-epub3        Transforms a DAISY 2.02 publication into an EPUB3
                               publication.
      daisy202-validator       Validates a DAISY 2.02 fileset.
@@ -182,33 +192,33 @@ in the "out" directory on the desktop of the user named "John Doe".
      html-to-pef              Transforms a HTML document into a PEF.
      nimas-fileset-validator  Validate a NIMAS Fileset. Supports inclusion of
                               MathML.
-     zedai-to-epub3           Transforms a ZedAI (DAISY 4 XML) document into an 
+     zedai-to-epub3           Transforms a ZedAI (DAISY 4 XML) document into an
                               EPUB 3 publication.
      zedai-to-html            Transforms ZedAI XML (ANSI/NISO Z39.98-2012 Authoring
                               and Interchange) into HTML.
      zedai-to-pef             Transforms a ZedAI (DAISY 4 XML) document into a PEF.
-  
-          
-  
+
+
+
   General commands:
-  
+
      status        Returns the status of the job with id JOB_ID
      delete        Removes a job from the pipeline
      results       Stores the results from a job
      jobs          Returns the list of jobs present in the server
      log           Stores the results from a job
-     queue         Shows the execution queue and the job's priorities. 
+     queue         Shows the execution queue and the job's priorities.
      moveup        Moves the job up the execution queue
      movedown      Moves the job down the execution queue
      clean         Removes the jobs with an ERROR status
      halt          Stops the webservice
      version       Prints the version and authentication information
-          
-  
-  
+
+
+
   List of global options:                 dp2 help -g
   List of admin commands:                 dp2 help -a
-  Detailed help for a single command:     dp2 help COMMAND  
+  Detailed help for a single command:     dp2 help COMMAND
 
 A complete user guide is in the works and will be available soon.
 
@@ -220,7 +230,7 @@ Please refer to the issue tracker:
  https://github.com/daisy/pipeline-issues/issues
 
 
-8. Contact 
+8. Contact
 ------------------------------------------------------------------------------
 
 If you want to join the effort and contribute to the Pipeline 2 project, feel


### PR DESCRIPTION
@rdeltour All the artifacts are staged. What is left to do now is to build the various packages. What is usually your workflow for that? Which packages do you build? Where do you upload a RC? Do you give the RC a non-snapshot version? Do you use the release plugin for the assembly? Do you update the release descriptor for the updater also for the RC?

These instructions could also go into the "super release script" I have made.

I have built the Windows ZIP, the EXE, the Mac OS ZIP, the DMG, the Linux ZIP, and the DEB.

This can definitely be made easier. Building them all at the same time is not possible, but when you try to build them one by one you end up building things more than once. This is part of https://github.com/daisy/pipeline-assembly/issues/75.

I hope I got everything right. You normally do this, and different machines may give different results. But I guess we'll find out when testing.

Depends on:
- https://github.com/daisy/pipeline-framework/compare/master...release/v1.10.3%5E
- https://github.com/daisy/xmlcalabash1/compare/org.daisy.libs...release/1.1.9-p1-95%5E
- https://github.com/daisy/jStyleParser/compare/org.daisy.libs...release/jStyleParser-1.20-p11%5E
- https://github.com/daisy/pipeline-mod-braille/compare/master...release/v1.10.1%5E
- https://github.com/daisy/pipeline-modules-common/compare/master...release/v1.10.3%5E
- https://github.com/daisy/pipeline-scripts-utils/compare/master...release/v1.10.2%5E
- https://github.com/daisy/pipeline-mod-tts/compare/master...release/v1.10.2%5E
- https://github.com/daisy/pipeline-build-utils/compare/master...release/integration%5E
- https://github.com/daisy/xproc-maven-plugin/compare/master...release/xproc-engine-daisy-pipeline-1.10.2%5E
- https://github.com/daisy/xspec-maven-plugin/compare/master...release/xspec-runner-1.0.2%5E


