### PR TITLE
Add support for CereProc TTS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+Changes in release v1.14.4
+==========================
+
+### Modules
+
+- **NEW** Support for CereProc text-to-speech engine
+
+
 Changes in release v1.14.3
 ==========================
 

--- a/pom.xml
+++ b/pom.xml
@@ -1124,6 +1124,10 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.daisy.pipeline.modules</groupId>
+                  <artifactId>tts-adapter-cereproc</artifactId>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.daisy.pipeline.modules</groupId>
                   <artifactId>tts-adapter-espeak</artifactId>
                 </artifactItem>
                 <artifactItem>

--- a/src/main/resources/etc/pipeline.properties
+++ b/src/main/resources/etc/pipeline.properties
@@ -121,6 +121,14 @@ org.daisy.pipeline.tts.config=${pipeline.config}/tts-default-config.xml
 #org.daisy.pipeline.tts.google.samplerate=22050
 #org.daisy.pipeline.tts.google.priority=15
 
+# CereProc settings
+#org.daisy.pipeline.tts.cereproc.server=localhost
+#org.daisy.pipeline.tts.cereproc.client=/usr/bin/cspeechclient
+#org.daisy.pipeline.tts.cereproc.port=8991
+#org.daisy.pipeline.tts.cereproc.priority=15
+#org.daisy.pipeline.tts.cereproc.dnn.port=8992
+#org.daisy.pipeline.tts.cereproc.dnn.priority=15
+
 # Lame settings
 #org.daisy.pipeline.tts.lame.path=
 #org.daisy.pipeline.tts.lame.cli.options=


### PR DESCRIPTION
This work was done for MTM by me and Carl Wålinder. A considerable part of the code was taken from Pipeline 1. NLB also plans to use this in the future.